### PR TITLE
Support relative PDF links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 /venv/
 __pycache__/
 *.egg-info/
+/build/
+/dist/
 
 !.gitkeep

--- a/mkdocs_pdf_export_plugin/preprocessor.py
+++ b/mkdocs_pdf_export_plugin/preprocessor.py
@@ -1,0 +1,41 @@
+import os
+
+from weasyprint import urls
+from bs4 import BeautifulSoup
+
+def get_rel_pdf_href(combined: bool, href: str):
+    head, tail = os.path.split(href)
+    filename, ext = tuple(os.path.splitext(tail))
+
+    absurl = urls.url_is_absolute(href)
+    abspath = os.path.isabs(href)
+    internal = href.startswith('#')
+    htmlfile = ext.startswith('.html')
+    if absurl or abspath or internal or not htmlfile:
+        return href
+
+    return urls.iri_to_uri(os.path.join(head, filename + '.pdf'))
+
+def get_abs_asset_href(base_url: str, href: str):
+    if urls.url_is_absolute(href) or os.path.isabs(href):
+        return href
+
+    return urls.iri_to_uri(urls.urljoin(base_url, href))
+
+def replace_hrefs(soup: BeautifulSoup, base_url: str, combined: bool):
+    # transforms all relative hrefs pointing to other html docs
+    # into relative pdf hrefs
+    for a in soup.find_all('a'):
+        try:
+            a['href'] = get_rel_pdf_href(combined, a['href'])
+        except KeyError:
+            pass
+
+    # makes all relative asset links absolute
+    for link in soup.find_all('link'):
+        try:
+            link['href'] = get_abs_asset_href(base_url, link['href'])
+        except KeyError:
+            pass
+
+    return soup

--- a/mkdocs_pdf_export_plugin/preprocessor.py
+++ b/mkdocs_pdf_export_plugin/preprocessor.py
@@ -25,17 +25,14 @@ def get_abs_asset_href(base_url: str, href: str):
 def replace_hrefs(soup: BeautifulSoup, base_url: str, combined: bool):
     # transforms all relative hrefs pointing to other html docs
     # into relative pdf hrefs
-    for a in soup.find_all('a'):
-        try:
-            a['href'] = get_rel_pdf_href(combined, a['href'])
-        except KeyError:
-            pass
+    for a in soup.find_all('a', href=True):
+        a['href'] = get_rel_pdf_href(combined, a['href'])
 
     # makes all relative asset links absolute
-    for link in soup.find_all('link'):
-        try:
-            link['href'] = get_abs_asset_href(base_url, link['href'])
-        except KeyError:
-            pass
+    for link in soup.find_all('link', href=True):
+        link['href'] = get_abs_asset_href(base_url, link['href'])
+
+    for asset in soup.find_all(src=True):
+        asset['src'] = get_abs_asset_href(base_url, asset['src'])
 
     return soup

--- a/mkdocs_pdf_export_plugin/preprocessor.py
+++ b/mkdocs_pdf_export_plugin/preprocessor.py
@@ -3,7 +3,7 @@ import os
 from weasyprint import urls
 from bs4 import BeautifulSoup
 
-def get_rel_pdf_href(combined: bool, href: str):
+def rel_pdf_href(href: str):
     head, tail = os.path.split(href)
     filename, ext = tuple(os.path.splitext(tail))
 
@@ -16,23 +16,71 @@ def get_rel_pdf_href(combined: bool, href: str):
 
     return urls.iri_to_uri(os.path.join(head, filename + '.pdf'))
 
-def get_abs_asset_href(base_url: str, href: str):
+def abs_asset_href(href: str, base_url: str):
     if urls.url_is_absolute(href) or os.path.isabs(href):
         return href
 
     return urls.iri_to_uri(urls.urljoin(base_url, href))
 
-def replace_hrefs(soup: BeautifulSoup, base_url: str, combined: bool):
+# makes all relative asset links absolute
+def replace_asset_hrefs(soup: BeautifulSoup, base_url: str):
+    for link in soup.find_all('link', href=True):
+        link['href'] = abs_asset_href(link['href'], base_url)
+
+    for asset in soup.find_all(src=True):
+        asset['src'] = abs_asset_href(asset['src'], base_url)
+    
+    return soup
+
+# normalize href to #foo/bar/section:id
+def normalized_href(href: str, rel_url: str):
+    head, tail = os.path.split(href)
+
+    num_hashtags = tail.count('#')
+    if num_hashtags is 0:
+        return href
+    elif num_hashtags > 1:
+        raise RuntimeError('Why are there so many hashtags in {}!?!?'.format(href))
+
+    if tail.startswith('#'):
+        head, section = os.path.split(rel_url)
+        section = os.path.splitext(section)[0]
+        id = tail[1:]
+    else:
+        section, ext = tuple(os.path.splitext(tail))
+        id = str.split(ext, '#')[1]
+
+    return '#{}/{}:{}'.format(head, section, id)
+
+# normalize id to foo/bar/section:id
+def normalized_id(id: str, rel_url: str):
+    if ':' in id or '/' in id:
+        print('":" and "/" characters are banned! /:')
+        raise RuntimeError('Invalid ID found in {}, ID: {}'.format(rel_url, id))
+
+    head, tail = os.path.split(rel_url)
+    section, _ = tuple(os.path.splitext(tail))
+
+    return '{}/{}:{}'.format(head, section, id)
+
+def prep_combined(soup: BeautifulSoup, base_url: str, rel_url: str):
+    for id in soup.find_all(id=True):
+        id['id'] = normalized_id(id['id'], rel_url)
+
+    for a in soup.find_all('a', href=True):
+        if urls.url_is_absolute(a['href']) or os.path.isabs(a['href']):
+            continue
+
+        a['href'] = normalized_href(a['href'], rel_url)
+
+    soup = replace_asset_hrefs(soup, base_url)
+    return soup
+
+def replace_hrefs(soup: BeautifulSoup, base_url: str):
     # transforms all relative hrefs pointing to other html docs
     # into relative pdf hrefs
     for a in soup.find_all('a', href=True):
-        a['href'] = get_rel_pdf_href(combined, a['href'])
+        a['href'] = rel_pdf_href(a['href'])
 
-    # makes all relative asset links absolute
-    for link in soup.find_all('link', href=True):
-        link['href'] = get_abs_asset_href(base_url, link['href'])
-
-    for asset in soup.find_all(src=True):
-        asset['src'] = get_abs_asset_href(base_url, asset['src'])
-
+    soup = replace_asset_hrefs(soup, base_url)
     return soup

--- a/mkdocs_pdf_export_plugin/preprocessor.py
+++ b/mkdocs_pdf_export_plugin/preprocessor.py
@@ -45,20 +45,24 @@ def replace_asset_hrefs(soup: BeautifulSoup, base_url: str):
 
 # normalize href to site root
 def normalize_href(href: str, rel_url: str):
+    # foo/bar/baz/../../index.html -> foo/index.html
+    def reduce_rel(x):
+        try:
+            i = x.index('..')
+            if i is 0:
+                return x
+
+            del x[i]
+            del x[i - 1]
+            return reduce_rel(x)
+        except ValueError:
+            return x
+
     rel_dir = os.path.dirname(rel_url)
     href = str.split(os.path.join(rel_dir, href), '/')
-    while True:
-        try:
-            i_of_rel = href.index('..')
-            if i_of_rel is 0:
-                break
-
-            del href[i_of_rel]
-            del href[i_of_rel - 1]
-        except ValueError:
-            break
-
+    href = reduce_rel(href)
     href[-1], _ = os.path.splitext(href[-1])
+
     return os.path.join(*href)
 
 # normalize href to #foo/bar/section:id

--- a/mkdocs_pdf_export_plugin/renderer.py
+++ b/mkdocs_pdf_export_plugin/renderer.py
@@ -9,7 +9,6 @@ from bs4 import BeautifulSoup
 from .themes import generic as generic_theme
 from . import preprocessor
 
-
 class Renderer(object):
     def __init__(self, combined: bool, theme: str, theme_handler_path: str=None):
         self.theme = self._load_theme_handler(theme, theme_handler_path)
@@ -20,7 +19,7 @@ class Renderer(object):
     def write_pdf(self, content: str, base_url: str, filename: str):
         self.render_doc(content, base_url).write_pdf(filename)
 
-    def render_doc(self, content: str, base_url: str):
+    def render_doc(self, content: str, base_url: str, rel_url: str = None):
         soup = BeautifulSoup(content, 'html.parser')
 
         stylesheet = self.theme.get_stylesheet()
@@ -30,12 +29,16 @@ class Renderer(object):
 
             soup.head.append(style_tag)
 
-        soup = preprocessor.replace_hrefs(soup, base_url, self.combined)
+        if self.combined:
+            soup = preprocessor.prep_combined(soup, base_url, rel_url)
+        else:
+            soup = preprocessor.replace_hrefs(soup, base_url)
+
         html = HTML(string=str(soup))
         return html.render()
 
     def add_doc(self, content: str, base_url: str, rel_url: str):
-        render = self.render_doc(content, base_url)
+        render = self.render_doc(content, base_url, rel_url)
         pos = self.page_order.index(rel_url)
         self.pages[pos] = render
 

--- a/mkdocs_pdf_export_plugin/renderer.py
+++ b/mkdocs_pdf_export_plugin/renderer.py
@@ -7,6 +7,7 @@ from weasyprint import HTML, Document
 from bs4 import BeautifulSoup
 
 from .themes import generic as generic_theme
+from . import preprocessor
 
 
 class Renderer(object):
@@ -29,7 +30,8 @@ class Renderer(object):
 
             soup.head.append(style_tag)
 
-        html = HTML(string=str(soup), base_url=base_url)
+        soup = preprocessor.replace_hrefs(soup, base_url, self.combined)
+        html = HTML(string=str(soup))
         return html.render()
 
     def add_doc(self, content: str, base_url: str, rel_url: str):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkdocs-pdf-export-plugin',
-    version='0.5.1b1',
+    version='0.5.1b3',
     description='An MkDocs plugin to export content pages as PDF files',
     long_description='The pdf-export plugin will export all markdown pages in your MkDocs repository as PDF files'
                      'using WeasyPrint. The exported documents support many advanced features missing in most other'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkdocs-pdf-export-plugin',
-    version='0.5.0',
+    version='0.5.1b1',
     description='An MkDocs plugin to export content pages as PDF files',
     long_description='The pdf-export plugin will export all markdown pages in your MkDocs repository as PDF files'
                      'using WeasyPrint. The exported documents support many advanced features missing in most other'


### PR DESCRIPTION
Currently, links such as `[Topic](topic.md)` become absolute links to their appropriate HTML files such as `file:///a/b/site/topic.html`.

This implements a preprocessor to overwrite all the hrefs accordingly. 

No support for combined PDF yet - this would require perhaps a generated id to replace all the anchor and href IDs of the single PDF document due to collision between naming of anchor IDs in multiple `.md` files.

Fixes #28.