### PR TITLE
Added Exception Handler. This is throwing pdf rendering issues for so…

### DIFF
--- a/mkdocs_pdf_export_plugin/renderer.py
+++ b/mkdocs_pdf_export_plugin/renderer.py
@@ -49,9 +49,12 @@ class Renderer(object):
     def write_combined_pdf(self, output_path: str):
         rendered_pages = []
         for p in self.pages:
-            render = self.render_doc(p[0], p[1], p[2])
-            self.pgnum += len(render.pages)
-            rendered_pages.append(render)
+            try:
+               render = self.render_doc(p[0], p[1], p[2])
+               self.pgnum += len(render.pages)
+               rendered_pages.append(render)
+            except:
+                print("Unexpected error:", sys.exc_info()[0])
 
         flatten = lambda l: [item for sublist in l for item in sublist]
         all_pages = flatten([p.pages for p in rendered_pages if p != None])


### PR DESCRIPTION
…me of markdown file. This will atleast generate pdf for remaining files.

Ideally any exception raised here has to be fixed. This is workaround to make pdfexport work for all other pages ignoring errored pages

**Sample exception i faced.**

INFO: Step 5 - Creating layout - Page 5
Traceback (most recent call last):
  File "/anaconda3/bin/mkdocs", line 11, in <module>
    load_entry_point('mkdocs==1.0.4', 'console_scripts', 'mkdocs')()
  File "/anaconda3/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/anaconda3/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/anaconda3/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/anaconda3/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/anaconda3/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/anaconda3/lib/python3.6/site-packages/mkdocs-1.0.4-py3.6.egg/mkdocs/__main__.py", line 163, in build_command
    ), dirty=not clean)
  File "/anaconda3/lib/python3.6/site-packages/mkdocs-1.0.4-py3.6.egg/mkdocs/commands/build.py", line 298, in build
    config['plugins'].run_event('post_build', config)
  File "/anaconda3/lib/python3.6/site-packages/mkdocs-1.0.4-py3.6.egg/mkdocs/plugins.py", line 94, in run_event
    result = method(item, **kwargs)
  File "/anaconda3/lib/python3.6/site-packages/mkdocs_pdf_export_plugin/plugin.py", line 119, in on_post_build
    self.renderer.write_combined_pdf(abs_pdf_path)
  File "/anaconda3/lib/python3.6/site-packages/mkdocs_pdf_export_plugin/renderer.py", line 52, in write_combined_pdf
    render = self.render_doc(p[0], p[1], p[2])
TypeError: 'NoneType' object is not subscriptable

(process:18022): GLib-GObject-CRITICAL **: 15:41:37.365: g_object_ref: assertion 'object->ref_count > 0' failed

(process:18022): GLib-GObject-CRITICAL **: 15:41:37.365: g_object_unref: assertion 'object->ref_count > 0' failed

(process:18022): GLib-GObject-CRITICAL **: 15:41:37.365: g_object_ref: assertion 'object->ref_count > 0' failed

(process:18022): GLib-GObject-CRITICAL **: 15:41:37.365: g_object_unref: assertion 'object->ref_count > 0' failed

